### PR TITLE
Updating CFPB docs link to shared docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ regulations-core, an API for hosting the parsed regulations and
 regulation-site, a front-end for the data structures generated.
 
 This repository is part of a larger project. To read about it, please see 
-[http://cfpb.github.io/eRegulations/](http://cfpb.github.io/eRegulations/).
+[http://eregs.github.io/eRegulations/](http://eregs.github.io/eRegulations/).
 
 ## Quick Start
 


### PR DESCRIPTION
Updating http://cfpb.github.io/eRegulations/ to http://eregs.github.io/eRegulations/ since the shared site has a more comprehensive explanation of the various agencies and repositories involved in this project.